### PR TITLE
Add a progress indicator

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -68,6 +68,13 @@ a:hover, a:focus, a:active {
   color: var(--accent-color-active);
 }
 
+i {
+  font-family: sans-serif;
+  font-size: 1.2em;
+  font-style: normal;
+  font-weight: normal;
+}
+
 b {
   font-weight: normal;
   font-size: 1.2em;

--- a/src/css/components/Report.css
+++ b/src/css/components/Report.css
@@ -33,6 +33,13 @@
   display: none;
 }
 
+.Report-sampleWarning {
+  border: 1px solid hsla(45, 100%, 50%, 0.15);
+  background: hsla(45, 100%, 50%, 0.15);
+  padding: 1em;
+  margin: 1em;
+}
+
 .Report-heading {
   color: #777;
   font-size: 0.9em;

--- a/src/index.html
+++ b/src/index.html
@@ -77,6 +77,8 @@
 
     <div class="Container Container--alternate">
       <section id="report" class="Report" hidden>
+        <div id="report-warnings"></div>
+
         <h2 class="Report-heading">Report</h2>
 
         <div class="Report-metric">

--- a/src/js/Progress.js
+++ b/src/js/Progress.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Progress {
+  init(onChange) {
+    this._total = 0;
+    this._cur = 0;
+
+    this._percentage = 0;
+    this._startTime = performance.now();
+    this._timeout;
+
+    this._onChange = () => {
+      clearTimeout(this._timeout);
+      if (performance.now() > this._startTime + 1000) {
+        onChange();
+      } else {
+        this._timeout = setTimeout(onChange, 1000);
+      }
+    };
+  }
+
+  get percentage() {
+    return this._percentage;
+  }
+
+  get cur() {
+    return this._cur;
+  }
+
+  set cur(val) {
+    this._cur = val;
+    this._updatePercentage();
+  }
+
+  get total() {
+    return this._total;
+  }
+
+  set total(val) {
+    this._total = val;
+    this._updatePercentage();
+  }
+
+  _updatePercentage() {
+    // Cap the % at 99 to account for chart render time.
+    const pct = Math.min(99, Math.floor(this._cur * 100 / this._total));
+    this._percentage = Math.max(this._percentage, pct);
+    this._onChange();
+  }
+}
+
+export const progress = new Progress();

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -21,7 +21,7 @@ import {getSegmentNameById} from './api.js';
 
 const getConfig = (id) => {
   const config = {
-    measurement_version: '7',
+    measurement_version: '8',
     page_path: location.pathname,
   };
 
@@ -204,6 +204,7 @@ export function measureReport({state, duration, report, error}) {
     event_category: 'Usage',
     event_label: error ? (error.code || error.message) : '(not set)',
     report_source: report ? report.meta.source : '(not set)',
+    report_sampled: Boolean(report && report.meta.isSampled),
   });
 }
 

--- a/src/js/charts.js
+++ b/src/js/charts.js
@@ -126,6 +126,19 @@ function drawTimeline(name, dateValues) {
   });
 }
 
+function drawWarnings(isSampled) {
+  document.getElementById('report-warnings').innerHTML =  isSampled ? `
+    <aside class="Report-sampleWarning">
+      <strong><i>⚠️</i> Warning:</strong>
+      This report is based on a sample of the full user base.
+      <a target="_blank"
+        href="https://support.google.com/analytics/answer/2637192">
+        Learn more.
+      </a>
+    </aside>
+  ` : ``;
+}
+
 function drawSummary(metric, segments) {
   const $el = document.getElementById(`summary-${metric}`);
   let html = ``;
@@ -320,7 +333,11 @@ function p75(values) {
   return '-'; // Insufficient data
 }
 
-export function renderCharts(data, reportOpts) {
+export function renderCharts(report, reportOpts) {
+  const {data, meta} = report;
+
+  drawWarnings(meta.isSampled);
+
   for (const [name, metric] of Object.entries(data.metrics)) {
     let maxValue;
     let bucketSize;

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getReport, getSegmentNameById} from './api.js';
+import {getReport, getSegmentNameById, PAGE_SIZE} from './api.js';
 import {WebVitalsError} from './WebVitalsError.js';
 
 
@@ -204,7 +204,7 @@ function buildReportRequest(state, opts) {
 
   return {
     viewId,
-    pageSize: 100000,
+    pageSize: PAGE_SIZE,
     // samplingLevel: 'SMALL',
     includeEmptyRows: true,
     dateRanges: [{startDate, endDate}],

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
+import {get, set} from './store.js';
+
 let state = {};
 const listenerMap = new Map();
 
 export function initState(initializer) {
-  let storedState = {};
-  try {
-    storedState = JSON.parse(localStorage.getItem('state'));
-  } catch (error) {
-    // Do nothing.
-  }
-  Object.assign(state, initializer(storedState));
-
-  document.addEventListener('visibilitychange', () => {
-    localStorage.setItem('state', JSON.stringify(state));
-  });
-
+  Object.assign(state, get('state'));
+  document.addEventListener('visibilitychange', () => set('state', state));
   return state;
 }
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function get(key) {
+  let value;
+  try {
+    value = JSON.parse(localStorage.getItem(key));
+  } catch (error) {
+    // Do nothing.
+  }
+  return value || {};
+}
+
+export function set(key, obj) {
+  try {
+    localStorage.setItem(key, JSON.stringify(obj));
+  } catch (error) {
+    // Do nothing.
+  }
+}


### PR DESCRIPTION
This PR adds a progress indicator to the process of fetching data from the cache and API to generate a report. In addition it makes the following improvements/fixes to the code:
- Fetches all subsequent requests for paginated reports in parallel rather than series
- Reads just the IndexedDB cache keys rather than the full cache values so it can start API requests more quickly (it then requests the cache values in parallel)
- Persists metadata for each report indicating the average number of entries per day. This is used in subsequent reports to determine whether or not requests should be broken up from the start.
- Adds a warning to the report indicating whether or not sampled data is being used.
- Fixes an issue where sampled data could be persisted to the cache.
- Fixes an issue where sampled data from one day could be merged with sampled data from another day. If the sample rates are different, this could affect the p75 values.