### PR TITLE
Add fallbacks for IndexedDB errors

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -208,6 +208,13 @@ export function measureReport({state, duration, report, error}) {
   });
 }
 
+export function measureCaughtError(error) {
+  gtag('event', 'caught_error', {
+    event_category: 'Usage',
+    event_label: error.stack || error.toString(),
+  });
+}
+
 export function initAnalytics() {
   if (location.hostname !== 'web-vitals-report.web.app') {
     window.gtag = console.log;

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -20,7 +20,7 @@ let state = {};
 const listenerMap = new Map();
 
 export function initState(initializer) {
-  Object.assign(state, get('state'));
+  Object.assign(state, initializer(get('state')));
   document.addEventListener('visibilitychange', () => set('state', state));
   return state;
 }


### PR DESCRIPTION
Fixes #15.

This PR adds logic to fallback to API requests whenever there's an error reading form the IndexedDB database. It also clears the database, which should help remove any corrupted data as well as handle cases where the store is getting too big (e.g. quota errors).