### PR TITLE
Add ability to optionally specify two additional segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ After you've logged in, a form will appear asking you to select:
 
 1. Your Google Analytics account (and [property](https://support.google.com/analytics/answer/2649554) and [view](https://support.google.com/analytics/answer/2649553))
 2. A date range to query
-3. Two [segments](https://support.google.com/analytics/answer/3123951) to compare results for
+3. Select the [segments](https://support.google.com/analytics/answer/3123951) to compare results for
 
 While the app does suggest a few interesting segments to compare, you're not limited to just these suggestions. If you select the bottom option "Choose segments", you'll be able to pick any segment you want.
 

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -172,7 +172,7 @@ export function measureWebVitals() {
 }
 
 function anonymizeSegment(id) {
-  if (id.match(/^-\d+$/)) {
+  if (id && id.match(/^-\d+$/)) {
     return getSegmentNameById(id);
   } else {
     return 'Custom Segment';
@@ -199,6 +199,8 @@ export function measureReport({state, duration, report, error}) {
     segments: [
       anonymizeSegment(state.segmentA),
       anonymizeSegment(state.segmentB),
+      anonymizeSegment(state.segmentC),
+      anonymizeSegment(state.segmentD),
     ].sort().join(', '),
     config: anonymizeConfig(state),
     event_category: 'Usage',

--- a/src/js/charts.js
+++ b/src/js/charts.js
@@ -19,7 +19,7 @@
 import {e, round} from './utils.js';
 
 
-const COLORS = ['#aaa', 'hsla(218, 88%, 50%, 0.7)'];
+const COLORS = ['#aaa', 'hsla(218, 88%, 50%, 0.7)', '#777', '#a7cccc'];
 
 function bucketValues(arrayOfValues, {maxValue, bucketSize = 10} = {}) {
   maxValue = maxValue || arrayOfValues[arrayOfValues.length - 1];

--- a/src/js/charts.js
+++ b/src/js/charts.js
@@ -177,7 +177,7 @@ function drawTable(id, dimensionName, dimensionData) {
       ${dimensionData.slice(0, 5).map(([dimension, values]) => {
         return segmentNames.map((segment, i) => `<tr>
           ${i === 0
-            ? `<td class="Table-dimension" rowspan="2">${e(dimension)}</td>`
+            ? `<td class="Table-dimension" rowspan="${segmentNames.length}">${e(dimension)}</td>`
             : ''}
           <td class="Table-segment">${e(segment)}</td>
           ${metricNames.map((metric) => {

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -39,15 +39,17 @@ export async function getWebVitalsData(state, opts) {
       [getSegmentNameById(segmentIdA)]: getDefaultValue(),
       [getSegmentNameById(segmentIdB)]: getDefaultValue(),
     }
+    
     // As Segments C and D are optional they may not exist
-    const segmentIdC = reportRequest.segments.length > 2 ? reportRequest.segments[2].segmentId.slice(6) : null;
-    if (segmentIdC) {
+    if (reportRequest.segments.length > 2) {
+      const segmentIdC = reportRequest.segments[2].segmentId.slice(6);
       retValue[getSegmentNameById(segmentIdC)] = getDefaultValue()
     }
-    const segmentIdD = reportRequest.segments.length > 3 ? reportRequest.segments[3].segmentId.slice(6) : null;
-    if (segmentIdD) {
+    if (reportRequest.segments.length > 3) {
+      const segmentIdD = reportRequest.segments[3].segmentId.slice(6);
       retValue[getSegmentNameById(segmentIdD)] = getDefaultValue()
     }
+    
     return retValue;
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -284,7 +284,7 @@ const app = (state, data) => {
               </select>
             </div>
             <div class="Form-field">
-              <label>Third segment</label>
+              <label>Third segment (optional)</label>
               <select id="segmentC">
                 <option value="">None</option>
                 ${data.segmentOpts ? html`
@@ -298,7 +298,7 @@ const app = (state, data) => {
               </select>
             </div>
             <div class="Form-field">
-              <label>Forth segment</label>
+              <label>Fourth segment (optional)</label>
               <select id="segmentD">
                 <option value="">None</option>
                 ${data.segmentOpts ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -118,8 +118,8 @@ function onDateRangeChange(newValue) {
 
 function onSegmentsRecommendedChange(newValue) {
   if (newValue) {
-    const [segmentA, segmentB] = newValue.split(',');
-    setState({segmentA, segmentB});
+    const [segmentA, segmentB, segmentC, segmentD] = newValue.split(',');
+    setState({segmentA, segmentB, segmentC, segmentD});
   }
 }
 
@@ -279,6 +279,34 @@ const app = (state, data) => {
                   </optgroup>
                   <optgroup label="Custom Segments">
                     ${renderOpts(state.segmentB, data.segmentOpts.CUSTOM)}
+                  </optgroup>
+                ` : null}
+              </select>
+            </div>
+            <div class="Form-field">
+              <label>Third segment</label>
+              <select id="segmentC">
+                <option value="">None</option>
+                ${data.segmentOpts ? html`
+                  <optgroup label="Built-in Segments">
+                    ${renderOpts(state.segmentC, data.segmentOpts.BUILT_IN)}
+                  </optgroup>
+                  <optgroup label="Custom Segments">
+                    ${renderOpts(state.segmentC, data.segmentOpts.CUSTOM)}
+                  </optgroup>
+                ` : null}
+              </select>
+            </div>
+            <div class="Form-field">
+              <label>Forth segment</label>
+              <select id="segmentD">
+                <option value="">None</option>
+                ${data.segmentOpts ? html`
+                  <optgroup label="Built-in Segments">
+                    ${renderOpts(state.segmentD, data.segmentOpts.BUILT_IN)}
+                  </optgroup>
+                  <optgroup label="Custom Segments">
+                    ${renderOpts(state.segmentD, data.segmentOpts.CUSTOM)}
                   </optgroup>
                 ` : null}
               </select>


### PR DESCRIPTION
This adds the ability to optionally set 2 more segments when using using Custom segment selection.

When using any of the pre-defined segments, there is no difference.

<img width="674" alt="image" src="https://user-images.githubusercontent.com/10931297/159177261-42d22dab-909b-400b-91b0-d78fbdefd1b0.png">

By default these are set to None (which are only available in these third and fourth options, as first two are mandatory):

<img width="687" alt="image" src="https://user-images.githubusercontent.com/10931297/159177235-0da0f3ad-5f98-4c5b-b43e-d159bf5ac5c3.png">

This useful when comparing segments:

<img width="929" alt="image" src="https://user-images.githubusercontent.com/10931297/159176341-a35b42f0-3285-4aef-8ba8-366354295d98.png">

Highcharts automatically gives them slightly different labels:

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/10931297/159176365-7d47237a-0392-47f7-884b-184aacf65f24.png">

And the table, now shows these segments:

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/10931297/159176385-daf7f6a9-bc4b-442d-84af-07cdce0c8c6b.png">

The histograms are less clear, but you can hover over the labels to see them:

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/10931297/159176411-b3b66677-385d-4454-8f01-356435edf2ae.png">




